### PR TITLE
Increase map flyTo zoom level to 18

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -30,7 +30,7 @@ const currentLocationIcon = new Icon({ iconUrl: 'pin.png', iconSize: [24, 24] })
 function SpotFlyTo({ lat, lng }: { lat: number; lng: number }) {
   const map = useMap();
   useEffect(() => {
-    map.flyTo([lat, lng], 17, { duration: 1.2 });
+    map.flyTo([lat, lng], 18, { duration: 1.2 });
   }, [lat, lng, map]);
   return null;
 }


### PR DESCRIPTION
Adjusted the zoom level in the SpotFlyTo component from 17 to 18 for a closer view when flying to a location.