### PR TITLE
Increase default map zoom level to 16

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -74,7 +74,7 @@ export default function MapView() {
       <div className="w-full h-1/2 md:h-full md:w-2/3">
         <MapContainer
           center={[35.6987, 139.7713]}
-          zoom={15}
+          zoom={16}
           scrollWheelZoom
           zoomControl={false}
           className="w-full h-full"


### PR DESCRIPTION
This pull request includes a minor update to the `MapView` component to adjust the default zoom level of the map.

* [`src/components/MapView.tsx`](diffhunk://#diff-bec1320c16bf65ed1803aba00528ab404abbf5786bed16db107596109e99192aL77-R77): Increased the `zoom` level in the `MapContainer` from `15` to `16` to provide a closer view by default.