### PR TITLE
Invert NSFW filter logic and update label

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -239,14 +239,14 @@ function SpotList({
         <input
           type="checkbox"
           id="nsfw-filter"
-          checked={nsfwFilter}
-          onChange={(e) => setNsfwFilter(e.target.checked)}
+          checked={!nsfwFilter}
+          onChange={(e) => setNsfwFilter(!e.target.checked)}
           className="sr-only peer"
         />
         <div className="w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-blue-600 transition-colors"></div>
         <div className="absolute left-1 top-1 w-4 h-4 bg-white rounded-full shadow transition-transform peer-checked:translate-x-5"></div>
           </div>
-          <span className="ml-3 text-sm text-gray-600">NSFW</span>
+          <span className="ml-3 text-sm text-gray-600">NSFWスポットも表示</span>
         </label>
       </div>
 


### PR DESCRIPTION
This pull request modifies the behavior and label of the NSFW filter toggle in the `SpotList` component within `src/components/MapView.tsx`. The changes ensure the toggle logic is inverted and update the label text.

Key changes:

* **Toggle behavior adjustment**:
  - The `checked` property now reflects the inverse of the `nsfwFilter` state, and the `onChange` handler updates the state accordingly. This corrects the toggle logic. (`[src/components/MapView.tsxL242-R249](diffhunk://#diff-bec1320c16bf65ed1803aba00528ab404abbf5786bed16db107596109e99192aL242-R249)`)

* **Label update**:
  - The label text for the NSFW filter toggle has been updated from "NSFW" to "NSFWスポットも表示" to provide a more descriptive and localized label. (`[src/components/MapView.tsxL242-R249](diffhunk://#diff-bec1320c16bf65ed1803aba00528ab404abbf5786bed16db107596109e99192aL242-R249)`)