### PR TITLE
Move body styles into :root selector

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,7 +1,6 @@
 @charset "UTF-8";
 @import "tailwindcss";
 
-
 :root {
   --background: #ffffff;
   --foreground: #171717;
@@ -19,6 +18,10 @@
     --background: #0a0a0a;
     --foreground: #ededed;
   }
+  body {
+    background: var(--background);
+    color: var(--foreground);
+  }
 }
 
 .wdxl-lubrifont-jp-n-regular {
@@ -26,7 +29,6 @@
   font-weight: 400;
   font-style: normal;
 }
-
 
 body {
   background: var(--background);


### PR DESCRIPTION
Relocated the body background and color styles inside the :root selector for improved CSS organization and to ensure theme variables are applied consistently.